### PR TITLE
Add support for KDK K12UC (fan with light)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Home Assistant custom integration to control KDK Airy fan (and light) over the i
 - KDK Airy E48HP (without light)
 - KDK Airy E48GP (with light)
 - KDK Airy F40GP (with light)
+- KDK K12UC (with light)
 
 ## Installation
 ### Via HACS

--- a/custom_components/kdk_airy/api.py
+++ b/custom_components/kdk_airy/api.py
@@ -82,7 +82,7 @@ class KdkDevice(NamedTuple):
     @property
     def has_lights(self):
         "Whether the fan device also has lights."
-        return self.product_code in ["E48GP", "48INCH-LED", "F40GP"]
+        return self.product_code in ["E48GP", "48INCH-LED", "F40GP", "K12UC"]
 
 
 @dataclass
@@ -228,6 +228,7 @@ class KdkApiClient:
         "E48GP",
         "48INCH-LED",
         "F40GP",
+        "K12UC",
     ]
 
     # Hard-coded values from the KDK Ceiling Fan app v1.1.0


### PR DESCRIPTION
## Summary
Adds the **KDK K12UC** to the supported devices. This model reports `product_code = "K12UC"` and includes a light.

- Added `K12UC` to `SUPPORTED_PRODUCT_CODES` so the device is discovered.
- Added `K12UC` to `KdkDevice.has_lights` so the light entity is created and the light-aware status packet is used.
- Added it to the README's Supported Devices list.

## Testing
Verified against a real K12UC unit using the existing command protocol:

- Fan: power on/off, speed 1–10, direction forward/reverse ✅
- Light: power on/off, brightness, colour temperature (warm↔white) ✅

The light commands work with the current code because `light.py` already sends the required `light_mode` (`day`/`night`) field alongside brightness/colour. No protocol changes were needed — only the product-code allow-lists.

## Notes
The unit is marketed as K12 series; the cloud API's `product_code` value is `K12UC`.