### PR TITLE
Add H56GP model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Home Assistant custom integration to control KDK Airy fan (and light) over the i
 ## Supported Devices
 - KDK Airy E48HP (without light)
 - KDK Airy E48GP (with light)
+- KDK Airy H56GP (with light)
 - KDK Airy F40GP (with light)
 - KDK K12UC (with light)
 

--- a/custom_components/kdk_airy/api.py
+++ b/custom_components/kdk_airy/api.py
@@ -82,7 +82,7 @@ class KdkDevice(NamedTuple):
     @property
     def has_lights(self):
         "Whether the fan device also has lights."
-        return self.product_code in ["E48GP", "48INCH-LED", "F40GP", "K12UC"]
+        return self.product_code in ["E48GP", "H56GP", "48INCH-LED", "F40GP", "K12UC"]
 
 
 @dataclass
@@ -226,6 +226,7 @@ class KdkApiClient:
     SUPPORTED_PRODUCT_CODES = [
         "E48HP",
         "E48GP",
+        "H56GP",
         "48INCH-LED",
         "F40GP",
         "K12UC",


### PR DESCRIPTION
The H56GP is a longer-blade variant of the E48GP and is protocol-identical (same cloud API and status/command packets). Adds it to `SUPPORTED_PRODUCT_CODES` and `has_lights`, and lists it in the README.

Tested working on a real H56GP unit — fan speed/direction and light brightness/colour all report and control correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxFRBErrk7CyBMoytHDgxM